### PR TITLE
feat: implement Value.amountOf

### DIFF
--- a/packages/pebble/src/compiler/path/getAbsolutePath.ts
+++ b/packages/pebble/src/compiler/path/getAbsolutePath.ts
@@ -63,7 +63,8 @@ function addExtension(path: string, endsWithSlash: boolean): string {
 
 export function isAbsolutePath( path: string ): boolean
 {
-    return path.startsWith( PATH_DELIMITER );
+    // Support both Unix (/) and Windows (C:/, D:/) absolute paths
+    return path.startsWith( PATH_DELIMITER ) || /^[A-Za-z]:[\\/]/.test( path );
 }
 
 export function getEnvRelativePath( filePath: string, projectRoot: string ): string | undefined

--- a/packages/pebble/src/compiler/tir/program/stdScope/stdScope.ts
+++ b/packages/pebble/src/compiler/tir/program/stdScope/stdScope.ts
@@ -23,6 +23,9 @@ import { TirReturnStmt } from "../../statements/TirReturnStmt";
 import { TirInlineClosedIR } from "../../expressions/TirInlineClosedIR";
 import { TirFuncT } from "../../types/TirNativeType";
 import { IRNative } from "../../../../IR/IRNodes/IRNative";
+import { IRFunc } from "../../../../IR/IRNodes/IRFunc";
+import { IRVar } from "../../../../IR/IRNodes/IRVar";
+import { _ir_apps } from "../../../../IR/IRNodes/IRApp";
 
 export const void_t = new TirVoidT();
 export const int_t = new TirIntT();
@@ -751,6 +754,7 @@ export function populatePreludeScope( program: TypedProgram ): void
     );
     if(!map_policyId_map_tokenName_int_t) throw new Error("expected map_policyId_map_tokenName_int_t");
     const valueLovelacesName = PEBBLE_INTERNAL_IDENTIFIER_PREFIX + "sortedValueLovelaces";
+    const valueAmountOfName = PEBBLE_INTERNAL_IDENTIFIER_PREFIX + "amountOfValue";
     const value_t = _defineUnambigousAlias(
         "Value",
         map_policyId_map_tokenName_int_t,
@@ -758,6 +762,10 @@ export function populatePreludeScope( program: TypedProgram ): void
             [
                 "lovelaces",
                 valueLovelacesName
+            ],
+            [
+                "amountOf",
+                valueAmountOfName
             ],
         ])
     );
@@ -769,7 +777,61 @@ export function populatePreludeScope( program: TypedProgram ): void
             SourceRange.unknown
         )
     );
-    
+    // Value.amountOf( policy: PolicyId, name: bytes ): int
+    // The IR native _amountOfValue is curried as: (isPolicy)(value)(isTokenName) => int
+    // where isPolicy and isTokenName are equality-check predicates.
+    // This wrapper adapts (self, policy, tokenName) => _amountOfValue(p => equalsByteString(p, policy))(self)(tn => equalsByteString(tn, tokenName))
+    preludeScope.program.functions.set(
+        valueAmountOfName,
+        new TirInlineClosedIR(
+            new TirFuncT([ value_t, policyId_t, bytes_t ], int_t ),
+            ( ctx ) => {
+                const self = Symbol("amtOf_self");
+                const policy = Symbol("amtOf_policy");
+                const tokenName = Symbol("amtOf_tokenName");
+                const p = Symbol("amtOf_p");
+                const tn = Symbol("amtOf_tn");
+                return new IRFunc(
+                    [ self ],
+                    new IRFunc(
+                        [ policy ],
+                        new IRFunc(
+                            [ tokenName ],
+                            _ir_apps(
+                                _ir_apps(
+                                    _ir_apps(
+                                        IRNative._amountOfValue,
+                                        // isPolicy predicate: \p -> equalsByteString(p, policy)
+                                        new IRFunc(
+                                            [ p ],
+                                            _ir_apps(
+                                                IRNative.equalsByteString,
+                                                new IRVar( p ),
+                                                new IRVar( policy )
+                                            )
+                                        )
+                                    ),
+                                    // value (self)
+                                    new IRVar( self )
+                                ),
+                                // isTokenName predicate: \tn -> equalsByteString(tn, tokenName)
+                                new IRFunc(
+                                    [ tn ],
+                                    _ir_apps(
+                                        IRNative.equalsByteString,
+                                        new IRVar( tn ),
+                                        new IRVar( tokenName )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                );
+            },
+            SourceRange.unknown
+        )
+    );
+
     /* // TODO
     untagged struct FlatValueEntry {
         policy: PolicyId,


### PR DESCRIPTION
## Summary

  This PR wires up the `Value.amountOf(policy: PolicyId, name: bytes): int` method that was planned (see the `TODO` comment in `stdScope.ts:776`) but not yet connected to the language surface.

  It also fixes a Windows compatibility issue in path resolution.

  ## Motivation

  `tx.mint` is typed as `Value` (`LinearMap<PolicyId, LinearMap<TokenName, int>>`), but there is currently **no way to inspect minted token quantities** from Pebble source code:

  - `Value.amountOf()` - listed as TODO, not registered on the type
  - `LinearMap.lookup()` - defined in the type system but `expressifyMethodCall` has no handler for it
  - No `builtin` keyword - UPLC builtins can't be called from `.pebble` files

  This makes it impossible to write mint validators that verify **what** was minted. For example, a minting policy that enforces "exactly 1 NFT with quantity 1" cannot be expressed.

  ```pebble
  // This is now possible with this PR:
  mint mintBatch(tokenName: bytes) {
      const { tx, policy } = context;
      assert tx.requiredSigners.includes(this.manufacturer);
      assert tx.mint.amountOf(policy, tokenName) == 1;
  }
 ```

Without amountOf, the mint validator can only check signatures not the actual minting action.

What was already done (by you)

The IR native _amountOfValue (IRNativeTag -41) in nativeToIR.ts is fully implemented - it walks the Value map structure, matches policy and token name via predicates, and returns the integer amount. The dispatch in nativeToIR (line 255) is also wired up. This PR just connects it to the Pebble language surface.

## Changes

1. packages/pebble/src/compiler/tir/program/stdScope/stdScope.ts
  - Register "amountOf" in the Value alias's methodsNamesPtr Map (alongside "lovelaces")
  - Register the function via preludeScope.program.functions.set() with a TirInlineClosedIR

The IR native _amountOfValue has a curried predicate-based signature: (isPolicy: bytes => bool)(value)(isTokenName: bytes =>   bool) => int. The registration builds an IR lambda that adapts the Pebble calling convention (self, policy, tokenName) to the native's signature:  \self \policy \tokenName -> _amountOfValue(\p -> equalsByteString(p, policy))(self)(\tn -> equalsByteString(tn, tokenName))

This follows the same pattern as lovelaces and getCredentialHash, so no changes needed in expressifyMethodCall or getPropAccessReturnType since the existing TirAliasType method resolution handles it automatically.

2. packages/pebble/src/compiler/path/getAbsolutePath.ts

- isAbsolutePath() only checked for / prefix (PATH_DELIMITER). On Windows, path.resolve() produces paths like C:/Users/... which are absolute but don't start with /. This caused double-concatenation of the project root, making compilation fail on Windows.

  Fix: also recognize C:/, D:\, etc. as absolute paths via /^[A-Za-z]:[\\\/]/.

 ## Testing

  - All 44 existing test suites pass (93 tests green, identical to main)
  - Manually verified: compiled a Plutus V3 mint+spend validator contract that uses tx.mint.amountOf(policy, tokenName) ==  1 produces valid UPLC output.
  - Happy to add a compiler.amountOf.test.ts if desired

## Context

Im trying to building a kind of an supply chain application i talked on Xyesterday to also showcase the capacy of my Catalyst Project as application backend on a supply chain use case. Its a pharmaceutical supply chain tracking system on Cardano. I had some simple Aiken Contracts done last month and was trying to rewrite it in Pebble today and hit the amountOf gap when writing the mint validator. Since the IR implementation was already complete, wiring it up was straightforward. 
( Contracts Implementation: https://github.com/ODATANO/TRACE/tree/main/contracts-pebble ) 
If you have any questions feel free to hit me up anytime 